### PR TITLE
Fix recency bug in functional updaters

### DIFF
--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,7 +1,7 @@
-import { mutate } from "./mutate"
-import { payloadError } from "./errors"
+import {mutate} from "./mutate"
+import {payloadError} from "./errors"
 
-import type { Action, State } from "./types"
+import type {Action, State} from "./types"
 
 export const reducer = (state: State, action: Action): State => {
 	const { past, present, future } = state
@@ -36,7 +36,16 @@ export const reducer = (state: State, action: Action): State => {
 		}
 	}
 
-	const update = () => mutate(state, action)
+	// Transform functional updater to raw value by applying it
+	const transform = (action: Action) => {
+		action.payload = typeof action.payload === "function"
+			? action.payload(present)
+			: action.payload
+
+		return action
+	}
+
+	const update = () => mutate(state, transform(action))
 
 	const reset = () => {
 		const { payload } = action

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,7 +1,7 @@
-import {mutate} from "./mutate"
-import {payloadError} from "./errors"
+import { mutate } from "./mutate"
+import { payloadError } from "./errors"
 
-import type {Action, State} from "./types"
+import type { Action, State } from "./types"
 
 export const reducer = (state: State, action: Action): State => {
 	const { past, present, future } = state

--- a/src/useUndoable.ts
+++ b/src/useUndoable.ts
@@ -77,9 +77,7 @@ const useUndoable = <T = any>(
 			mutationBehavior: MutationBehavior = options.behavior,
 			ignoreAction: boolean = false
 		) => {
-			return typeof payload === "function"
-				? update(payload(state.present), mutationBehavior, ignoreAction)
-				: update(payload, mutationBehavior, ignoreAction)
+			return update(payload, mutationBehavior, ignoreAction)
 		},
 		[state]
 	)


### PR DESCRIPTION
In the current version, the handling of executing a functional updater results in unexpected behaviour, compared to React's own functional update handling in `useState`.

The situation concerns calling the setter twice before one render. According to `useState`, the second call should take into account the updated (but not yet rendered) value of the first update call. This is currently not the case in `useUndoable`, as this takes into account only the recent value latest rendered. This has to do with the functional updater being executed in the `useUndoable` hook, which indeed, only knows the rendered value as most recent one.

E.g. in code:

```js

const [count, setCount] = useUndoable(0)

...
  setCount(old => old + 1); // expected: 1, actual: 1
  setCount(old => old + 1); // expected: 2, actual: 1
...
```

This PR fixes the issue by moving the execution of the functional updater from the hook code, to the reducer. The reducer code _does_ take into account the value of the first update.

