### PR TITLE
Provide a stable setState method

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -59,5 +59,10 @@ export type UseUndoable<T> = [
 			behavior?: MutationBehavior,
 			ignoreAction?: boolean
 		) => void
+		setStateStable: (
+			payload: T | ((oldValue: T) => T),
+			behavior?: MutationBehavior,
+			ignoreAction?: boolean
+		) => void
 	}
 ]

--- a/src/useUndoable.ts
+++ b/src/useUndoable.ts
@@ -1,4 +1,4 @@
-import { useReducer, useCallback, Reducer } from "react"
+import { useReducer, useCallback, Reducer, useRef } from "react"
 
 import { reducer } from "./reducer"
 
@@ -95,6 +95,19 @@ const useUndoable = <T = any>(
 		[state]
 	)
 
+	const setStateRef = useRef(setState)
+	setStateRef.current = setState;
+
+	const setStateStable = useCallback((
+		payload: any,
+
+		// @ts-ignore
+		mutationBehavior: MutationBehavior = options.behavior,
+		ignoreAction: boolean = false
+	) => {
+		return setStateRef.current(payload, mutationBehavior, ignoreAction)
+	}, [setStateRef])
+
 	// In some rare cases, the fact that the above setState
 	// function changes on every render can be problematic.
 	// Since we can't really avoid this (setState uses
@@ -126,6 +139,7 @@ const useUndoable = <T = any>(
 			reset,
 			resetInitialState,
 			static_setState,
+			setStateStable
 		},
 	]
 }


### PR DESCRIPTION
Hello. Thanks for all the hard work you put in here.

I was a bit surprised the setState function was not stable. In react when using `useState` that function is always stable. This repo, which does try and mirror that pattern, has made a different choice. I was looking at past conversations and I don't 100% understand why, but no worries.

I was wondering if you could also export a stable function like the one I have in this PR? I'm sure the `static_setState` is helpful to some but I don't see a reason to not also provide a more common stable function. I've been using it in my own project and I don't know of any downsides.

again, thanks for your hard work and I hope this kind of addition is considered.